### PR TITLE
chore: remove unused ConfigDict import in profile.py

### DIFF
--- a/backend/app/schemas/profile.py
+++ b/backend/app/schemas/profile.py
@@ -2,7 +2,7 @@ from datetime import date, datetime
 from typing import Literal
 from urllib.parse import urlparse
 
-from pydantic import BaseModel, ConfigDict, Field, HttpUrl, field_validator, model_validator
+from pydantic import BaseModel, Field, HttpUrl, field_validator, model_validator
 
 from app.schemas.country_options import COUNTRIES
 from app.schemas.education import EducationCreate, EducationRead


### PR DESCRIPTION
## 概要

`backend/app/schemas/profile.py` の `ConfigDict` import が未使用のため削除します(#122 Option A)。

- L5: `from pydantic import BaseModel, ConfigDict, Field, HttpUrl, field_validator, model_validator`
- L69: `model_config = {\"from_attributes\": True}` (plain dict literal、`ConfigDict` 不使用)

ruff F401 (unused-import) で flag されるパターンです。

Option B(`ConfigDict(from_attributes=True)` への戻し)は、meaintainer が意図的に dict literal に切り替えた経緯を尊重して採用していません。

Closes #122

## 動作確認

- 変更は **1 行のみ**(L5 の import から `ConfigDict` を除去)
- `python -c "import ast; ast.parse(...)"` で構文 OK 確認
- ファイル内に `ConfigDict` の他参照無しを `grep -n "ConfigDict"` で確認(結果 0 件)
- gitleaks v8.30.1 でスキャン clean
- 他の schema ファイル(`admin.py` / `auth.py` / `education.py` 等)は無変更

ランタイム挙動は不変です(`from_attributes` の挙動は dict literal 形式で既に効いています)。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code cleanup and optimization with no impact on user-facing functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AsimAftab/Scholr/pull/127)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->